### PR TITLE
[Bugfix/GXA-476] Update the resource section title and bump version to 1.22.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/expression-atlas-experiment-page",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/expression-atlas-experiment-page",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "Expression Atlas experiment page frontend e.g. https://www.ebi.ac.uk/gxa/experiments/E-MTAB-513",
   "main": "lib/index.js",
   "scripts": {

--- a/src/tabs/resources/Main.js
+++ b/src/tabs/resources/Main.js
@@ -115,8 +115,7 @@ class ResourcesTab extends Component {
         resourcesFetch.value.length >= 1 &&
         <DisclaimerWrapper disclaimer={disclaimer}>
           <div className={`small-12 columns margin-bottom-xlarge`}>
-            <h3 key={`title`}>Curated Analysis Files</h3>
-            <p>Processed expression data, experimental design, and R-ready results:</p>
+            <h3 key={`title`}>Analysis Results</h3>
             <ResourcesSection
               values={metadataResources}
               {...{pathToResources, atlasUrl}} />


### PR DESCRIPTION
Renamed the "Curated Analysis Files" heading to "Analysis Results" for clarity and updated the accompanying description. Additionally, incremented the package version from 1.22.1 to 1.22.2 to reflect these changes.